### PR TITLE
Added YARA rules for Matanbuchus and QBOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [version] - 2025-02-08
+## [1.0.1] - 2025-02-10
+
+### Added
+
+- V1.1 Folders for YARA, Snort, and Sigma rules
+- V1.1 Added YARA detection rule for Matanbuchus
+- V1.1 Added YARA detection rule for QBOT

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # 	DE&TH Detection Repository
+
+
+Repository for the for the Detection Engineering & Threat Hunting (DE&TH) course. Within this project there are detectors for file detections via YARA, network detections via snort, and a wider range of use-cases available in the SigmaHQ project.

--- a/yara/Matanbuchus_2024_04_09.yar
+++ b/yara/Matanbuchus_2024_04_09.yar
@@ -1,0 +1,37 @@
+import "pe"
+
+rule MAL_WIN_Matanbuhchus_Loader_PE
+{
+    meta:
+        description = "Detects Matanbuhchus masquerading as a CPL file"
+        author="James Jolley"
+        date="2024-04-09"
+        reference="https://github.com/pr0xylife/Matanbuchus/blob/main/Matanbuchus_07.03_2024.txt"
+        hash="1ca1315f03f4d1bca5867ad1c7a661033c49bbb16c4b84bea72caa9bc36bd98b"
+    strings:
+        $s1= "DllRegisterServer"
+        $s2= "DllUnregisterServer"
+        $s3= "_RegisterDll@12"
+        $s4= "_UnregisterDll@4"
+        $s5= "EmulateCallWaiting"
+        $s6= "AppPolicyGetProcessTerminationMethod"
+        $s7= "** GET_MSG_BODY **" wide
+        $s8= "Receiver - Got NAK" wide
+        $s9= "Start Monitoring A" wide
+        $s10= "operator<=>" fullword
+        $s11= "MohOverrideActionF"wide
+        $s12= "ModemMonitor(RKMON"wide
+        $s13= "** GET_CHECKSUM **"
+        $s14= "** CHOSEN_DATA_PUM"
+        $s15= "operator co_await"
+        $s16= "** StartIdle **"
+        $s17= "win32.DLL" fullword
+    condition:
+        pe.is_pe and 
+        filesize < 750KB and
+        pe.imports("KERNEL32.dll","IsDebuggerPresent") and
+        pe.exports("DllRegisterServer") and
+        all of ($s*)
+}
+
+

--- a/yara/Qbot_2024_04_09.yar
+++ b/yara/Qbot_2024_04_09.yar
@@ -1,0 +1,37 @@
+import "pe"
+
+rule MAL_WIN_Trojan_Qbot
+{
+    meta:
+        description = "Detects qbot trojan"
+        author="James Jolley"
+        date="2024-04-09"
+        reference = "https://redcanary.com/threat-detection-report/threats/qbot/"
+        hash="6a8557a2f8e1338e6edb2a07c345882389230ea24ffeb741a59621b7e8b56c59"
+	strings:
+		$s1 = "Tdk_threads_mutex" 
+		$s2 = "Tdk_window_process_all_updates" 
+		$s3 = "Tdk_window_process_updates" 
+		$s4 = "Tdk_spawn_command_line_on_screen" 
+		$s5 = "Tdk_drag_context_list_targets" 
+		$s6 = "Tdk_win32_selection_add_targets" 
+		$s7 = "Tdk_utf8_to_string_target" 
+		$s8 = "gdk_pango_renderer_set_drawable() and gdk_pango_renderer_set_drawable()must be used to set the target drawable and GC before usi" ascii
+		$s9 = "Tdk_spawn_on_screen_with_pipes" 
+		$s10 = "  VirtualQuery failed for %d bytes at address %p" 
+		$s11 = "Tdk_device_get_key" 
+		$s12 = "Tdk_screen_get_system_visual" 
+		$s13 = "Tdk_window_get_root_coords" 
+        $s14 = "AccessX_Enable"
+		$s15 = "Tdk_window_get_user_data" 
+		$s16 = "Tdk_window_get_root_origin" 
+		$s17 = "Tdk_keymap_get_entries_for_keycode" 
+		$s18 = "GIMP Drawing Kit" wide
+        $s19 = "WACOM Tablet" wide
+        $s20 = "gdkWindowTempShadow" wide
+        $h1 = { 4D 5A }
+    condition:
+        pe.characteristics & pe.DLL and
+        filesize < 1000KB and
+        all of ($s*)
+}   


### PR DESCRIPTION
Created folders for YARA, Sigma, and Snort rules, respectively. These will be used to stage, develop, test, and deploy detection rules.  Added YARA rules for Matanbuchus and QBOT